### PR TITLE
Aliased with long package names "A::Name" doesn't work inside a package

### DIFF
--- a/t/aliased.t
+++ b/t/aliased.t
@@ -2,7 +2,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 16;
+use Test::More tests => 18;
 
 #use Test::More qw/no_plan/;
 
@@ -46,3 +46,15 @@ foreach my $method (qw/foo bar baz/) {
     is &$method, $method, '... and it should behave as expected';
 }
 
+package My::Package;
+use Test::More;
+
+use aliased 'Really::Long::Module::Name';
+my $name = Name->new;
+isa_ok $name, 'Really::Long::Module::Name',
+    '... a short alias works in a package';
+
+use aliased 'Really::Long::Module::Name' => 'A::Name';
+$name = A::Name->new;
+isa_ok $name, 'Really::Long::Module::Name',
+    '... a long alias works in a package';


### PR DESCRIPTION
I haven't had time to work out why yet, we are still using 0.21 where it does work.  I thought a test that shows the problem is better than nothing for now.

If I get some free time before someone else fixes it I will see what I can do.
