### PR TITLE
resolves ovid/aliased/pull/3

### DIFF
--- a/lib/aliased.pm
+++ b/lib/aliased.pm
@@ -1,6 +1,6 @@
 package aliased;
 
-our $VERSION = '0.30_01';
+our $VERSION = '0.30_02';
 $VERSION = eval $VERSION;
 
 require Exporter;
@@ -38,8 +38,12 @@ sub _make_alias {
 
     $alias ||= _get_alias($package);
 
+    my $destination = $alias =~ /::/
+      ? $alias
+      : "$callpack\::$alias";
+
     no strict 'refs';
-    *{ join q{::} => $callpack, $alias } = sub () { $package };
+    *{ $destination } = sub () { $package };
 }
 
 sub _load_alias {

--- a/t/aliased.t
+++ b/t/aliased.t
@@ -2,9 +2,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 16;
-
-#use Test::More qw/no_plan/;
+use Test::More tests => 18;
 
 BEGIN {
     chdir 't' if -d 't';
@@ -46,3 +44,15 @@ foreach my $method (qw/foo bar baz/) {
     is &$method, $method, '... and it should behave as expected';
 }
 
+{
+  package My::Package;
+  use Test::More;
+
+  use aliased 'Really::Long::Module::Name';
+  my $name = Name->new;
+  isa_ok $name, 'Really::Long::Module::Name', '... a short alias works in a package';
+
+  use aliased 'Really::Long::Module::Name' => 'A::Name';
+  $name = A::Name->new;
+  isa_ok $name, 'Really::Long::Module::Name', '... a long alias works in a package';
+}


### PR DESCRIPTION
This commit resolves https://github.com/Ovid/aliased/pull/3 ; with it, creating aliases in other packages works again.

This was inadvertently broken in 1a7fc99f3487bb16193833803fa392fc9c24bfa2
when $callpack was universally prepended to $alias. Apparently github user http://github.com/afresh1 relied on the old behavior.
