### PR TITLE
Simplify import ; don't inherit from Exporter

### DIFF
--- a/lib/aliased.pm
+++ b/lib/aliased.pm
@@ -4,7 +4,6 @@ our $VERSION = '0.30_02';
 $VERSION = eval $VERSION;
 
 require Exporter;
-@ISA    = qw(Exporter);
 @EXPORT = qw(alias prefix);
 
 use strict;
@@ -15,12 +14,10 @@ sub _croak {
 }
 
 sub import {
-    my ( $class, $package, $alias, @import ) = @_;
+    # Without args, just export @EXPORT
+    goto &Exporter::import if @_ <= 1;
 
-    if ( @_ <= 1 ) {
-        $class->export_to_level(1);
-        return;
-    }
+    my ( $class, $package, $alias, @import ) = @_;
 
     my $callpack = caller(0);
     _load_alias( $package, $callpack, @import );


### PR DESCRIPTION
`@ISA = qw(Exporter)` is only used to allow to call `$class->export_to_level(1)` in `->import`. This is a way to tell Exporter to do its usual job.
But a simpler way to just forward `->import` to `Exporter` is to use `goto`.
This avoids to pollute our `@ISA`.

Note that this patch is based on the latest code from Github, which unfortunately is older than the latest release on CPAN (see #5). I'll rebase it once #5 is resolved.
